### PR TITLE
Remove AudiusKitIntents docs

### DIFF
--- a/documentation/Getting-Started.md
+++ b/documentation/Getting-Started.md
@@ -32,7 +32,7 @@ AudiusKit is a Swift package for integrating Audius music content into your iOS,
    ```
    https://github.com/julianbaker/AudiusKit.git
    ```
-3. Select the latest version and add the `AudiusKit` (and `AudiusKitIntents` if needed) products to your target.
+3. Select the latest version and add the `AudiusKit` product to your target.
 
 ### Package.swift Example
 ```swift

--- a/documentation/Troubleshooting.md
+++ b/documentation/Troubleshooting.md
@@ -57,15 +57,9 @@
 
 ## Debugging Tips
 - Use logs and breakpoints to inspect API responses and errors.
-- Use the provided validation methods:
-  ```swift
-  try AudiusKitIntentsPackage.validateConfiguration()
-  let status = AudiusKitIntentsPackage.getIntegrationStatus()
-  ```
 - Check for common error messages:
   - "No available hosts"
   - "Failed to decode response"
-  - "Intents not appearing"
   - "Network connection required"
 - If you encounter persistent issues, update AudiusKit to the latest version and consult the [Usage Guide](https://github.com/julianbaker/AudiusKit/blob/main/documentation/Usage-Guide.md) or [API Reference](https://github.com/julianbaker/AudiusKit/blob/main/documentation/API-Reference.md).
 

--- a/documentation/Usage-Guide.md
+++ b/documentation/Usage-Guide.md
@@ -342,7 +342,7 @@ Trigger `loadMoreTrendingTracks()` as the user scrolls to the bottom of your lis
 ## Testing & Network Requirements
 
 - Most tests in AudiusKitTests require a live network connection and access to the Audius API.
-- Tests in AudiusKitIntentsTests using MockAudiusAPIClient can be run offline and are suitable for verifying logic and pagination without network access.
+- Mock-based tests using `MockAudiusAPIClient` can be run offline and are suitable for verifying logic and pagination without network access.
 - For CI or local development without network, focus on mock-based tests.
 
 ---


### PR DESCRIPTION
## Summary
- update docs to remove references to AudiusKitIntents and its tests

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68682951dedc832d987d6e512d333716