### PR TITLE
Fix playlists endpoint return type

### DIFF
--- a/Sources/AudiusKit/Models/ImageTypes.swift
+++ b/Sources/AudiusKit/Models/ImageTypes.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 #if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit

--- a/Sources/AudiusKit/Networking/AudiusAPIClient.swift
+++ b/Sources/AudiusKit/Networking/AudiusAPIClient.swift
@@ -1,6 +1,10 @@
 import Foundation
+#if canImport(Network)
 import Network
+#endif
+#if canImport(OSLog)
 import OSLog
+#endif
 
 /// A client for interacting with the Audius API
 public actor AudiusAPIClient {
@@ -717,13 +721,13 @@ public actor AudiusAPIClient {
     offset: Int = 0,
     limit: Int = 20,
     forceRefresh: Bool = false
-  ) async throws -> [Track] {
+  ) async throws -> [Playlist] {
     let safeOffset = max(0, offset)
     let safeLimit = max(0, limit)
     if safeLimit == 0 { return [] }
     let cacheKey = "playlists_\(userId)_\(safeOffset)_\(safeLimit)"
     if !forceRefresh {
-      if let cached: [Track] = await cacheManager.getCachedMetadata(forKey: cacheKey) {
+      if let cached: [Playlist] = await cacheManager.getCachedMetadata(forKey: cacheKey) {
         return cached
       }
     }
@@ -735,7 +739,7 @@ public actor AudiusAPIClient {
     ]
     let url = try await constructURL(path: "users/\(userId)/playlists", queryItems: queryItems)
     logger.debug("Requesting playlists from URL: \(url)")
-    let response: TracksResponse = try await fetch(url: url)
+    let response: PlaylistsResponse = try await fetch(url: url)
     await cacheManager.cacheMetadata(response.data, forKey: cacheKey)
     return response.data
   }

--- a/Sources/AudiusKit/Networking/CacheManager.swift
+++ b/Sources/AudiusKit/Networking/CacheManager.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 #if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit

--- a/documentation/API-Reference.md
+++ b/documentation/API-Reference.md
@@ -87,7 +87,7 @@ func fetchSupporting(userId: String, offset: Int = 0, limit: Int = 20, forceRefr
 func fetchMutuals(userId: String, offset: Int = 0, limit: Int = 20, forceRefresh: Bool = false) async throws -> [Track.User]
 
 // Fetch playlists by user (paginated)
-func fetchUserPlaylists(userId: String, offset: Int = 0, limit: Int = 20, forceRefresh: Bool = false) async throws -> [Track]
+func fetchUserPlaylists(userId: String, offset: Int = 0, limit: Int = 20, forceRefresh: Bool = false) async throws -> [Playlist]
 
 // Fetch reposts by user (paginated)
 func fetchUserReposts(userId: String, offset: Int = 0, limit: Int = 20, forceRefresh: Bool = false) async throws -> [Track]


### PR DESCRIPTION
## Summary
- fix `fetchUserPlaylists` to return `[Playlist]` instead of `[Track]`
- update API reference docs
- support building without SwiftUI, Network, or OSLog modules on non-Apple platforms

## Testing
- `swift test` *(fails: unsupported platform -- OS frameworks missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868174ec1a0832d98593577d6ff25fa