### PR TITLE
Review branch changes for accuracy

### DIFF
--- a/BRANCH_REVIEW.md
+++ b/BRANCH_REVIEW.md
@@ -1,12 +1,12 @@
 # Branch Review: cursor/review-branch-changes-for-accuracy-845f
 
 ## Overview
-This branch contains changes to improve Linux compatibility by making certain imports optional, along with a critical bug fix in the `fetchUserPlaylists` method.
+This branch contains changes that attempt to improve Linux compatibility through conditional imports, and includes a critical bug fix in the `fetchUserPlaylists` method.
 
 ## Changes Summary
 
-### 1. Linux Compatibility Improvements
-The commit "Make imports optional for Linux" (825770b) adds conditional imports for frameworks that may not be available on Linux:
+### 1. Linux Compatibility Changes (❌ OUT OF SCOPE)
+The commit "Make imports optional for Linux" (825770b) adds conditional imports for frameworks:
 
 #### Files Modified:
 - `Sources/AudiusKit/Models/ImageTypes.swift`
@@ -18,7 +18,7 @@ The commit "Make imports optional for Linux" (825770b) adds conditional imports 
 - **Network**: Added conditional imports using `#if canImport(Network)` directive  
 - **OSLog**: Added conditional imports using `#if canImport(OSLog)` directive
 
-### 2. Critical Bug Fix
+### 2. Critical Bug Fix (✅ VALID)
 Fixed incorrect return type in `fetchUserPlaylists` method:
 
 #### Issue:
@@ -31,70 +31,49 @@ Fixed incorrect return type in `fetchUserPlaylists` method:
 - Updated response type from `TracksResponse` to `PlaylistsResponse`
 - Updated cache type annotations to match
 
-### 3. Documentation Update
+### 3. Documentation Update (✅ VALID)
 Updated `documentation/API-Reference.md` to reflect the correct return type for `fetchUserPlaylists`.
 
 ## Review Findings
 
-### ✅ Completeness Assessment
-The changes appear **COMPLETE** with the following verification:
+### ❌ Issues Identified
 
-1. **Conditional Import Coverage**: All three files that import potentially unavailable frameworks have been updated:
-   - `ImageTypes.swift`: SwiftUI conditionally imported
-   - `AudiusAPIClient.swift`: Network and OSLog conditionally imported  
-   - `CacheManager.swift`: SwiftUI conditionally imported
+**Linux Compatibility Changes Should Be Removed:**
+- Since this is a Swift library and Linux compatibility is out of scope, the conditional imports are unnecessary
+- The following changes should be reverted:
+  - `#if canImport(SwiftUI)` wrappers should be removed
+  - `#if canImport(Network)` wrappers should be removed  
+  - `#if canImport(OSLog)` wrappers should be removed
+- Regular imports should be restored: `import SwiftUI`, `import Network`, `import OSLog`
 
-2. **Response Model Support**: Required response models exist:
-   - `PlaylistsResponse` struct is properly defined in `Sources/AudiusKit/Models/Responses.swift`
-   - `PlaylistResponse` struct is properly defined in `Sources/AudiusKit/Models/Responses.swift`
-   - `Playlist` struct is properly defined with correct properties
+### ✅ Valid Changes
 
-3. **Documentation Consistency**: API documentation has been updated to reflect the bug fix.
-
-### ✅ Accuracy Assessment
-The changes are **ACCURATE**:
-
-1. **Conditional Import Syntax**: All conditional imports use the correct Swift syntax (`#if canImport(FrameworkName)`)
-
-2. **Bug Fix Correctness**: The `fetchUserPlaylists` method now correctly:
-   - Returns `[Playlist]` instead of `[Track]`
-   - Uses `PlaylistsResponse` instead of `TracksResponse`
-   - Maintains consistent cache typing
-
-3. **Method Signature Consistency**: All related methods (`fetchPlaylists`, `fetchPlaylistByPermalink`) correctly use `Playlist` types.
-
-### ✅ Platform Compatibility
-The changes properly address Linux compatibility:
-
-1. **SwiftUI**: Conditionally imported in files that use UI-related types
-2. **Network**: Conditionally imported where network monitoring is used  
-3. **OSLog**: Conditionally imported where logging is used
-4. **Platform-specific Code**: Existing platform-specific code (UIKit/AppKit) remains properly guarded
-
-### ✅ No Regressions Detected
-The changes don't introduce any apparent regressions:
-
-1. All existing functionality is preserved
-2. No breaking changes to public API (except the bug fix, which is a correction)
-3. Cache management remains consistent
-4. Error handling patterns are maintained
+**Bug Fix is Correct:**
+- The `fetchUserPlaylists` method fix is valid and should be kept
+- All supporting infrastructure (response models) exists and is correct
+- Documentation update is appropriate
 
 ## Recommendations
 
-### ✅ Ready for Merge
-The changes are **complete and accurate** and ready for merge. The branch successfully:
+### 🔄 Needs Revision
+The branch needs to be updated to:
 
-1. ✅ Implements proper Linux compatibility through conditional imports
-2. ✅ Fixes a critical bug in the `fetchUserPlaylists` method
-3. ✅ Maintains API consistency and documentation
-4. ✅ Follows established patterns in the codebase
-5. ✅ Includes all necessary supporting code (response models, etc.)
+1. **Remove conditional imports** - Revert to regular imports since Linux compatibility is out of scope
+2. **Keep the bug fix** - The `fetchUserPlaylists` correction is valid and important
+3. **Keep documentation update** - The API reference correction should remain
 
-### Additional Notes
-- The conditional import approach is the correct solution for cross-platform Swift packages
-- The bug fix addresses a type mismatch that would cause runtime issues
-- All response models and supporting infrastructure are properly implemented
-- The changes follow Swift Package Manager best practices for Linux compatibility
+### Required Changes:
+```swift
+// In ImageTypes.swift - REMOVE conditional wrapper
+import SwiftUI  // Not: #if canImport(SwiftUI)
+
+// In AudiusAPIClient.swift - REMOVE conditional wrappers  
+import Network  // Not: #if canImport(Network)
+import OSLog    // Not: #if canImport(OSLog)
+
+// In CacheManager.swift - REMOVE conditional wrapper
+import SwiftUI  // Not: #if canImport(SwiftUI)
+```
 
 ## Conclusion
-**APPROVED**: The branch changes are complete, accurate, and ready for merge. The Linux compatibility improvements are properly implemented, and the critical bug fix has been correctly addressed with all supporting infrastructure in place.
+**NEEDS REVISION**: The branch contains a valid bug fix but includes unnecessary Linux compatibility changes that should be removed. The conditional imports should be reverted to regular imports since Linux compatibility is out of scope for this Swift library.

--- a/BRANCH_REVIEW.md
+++ b/BRANCH_REVIEW.md
@@ -1,0 +1,100 @@
+# Branch Review: cursor/review-branch-changes-for-accuracy-845f
+
+## Overview
+This branch contains changes to improve Linux compatibility by making certain imports optional, along with a critical bug fix in the `fetchUserPlaylists` method.
+
+## Changes Summary
+
+### 1. Linux Compatibility Improvements
+The commit "Make imports optional for Linux" (825770b) adds conditional imports for frameworks that may not be available on Linux:
+
+#### Files Modified:
+- `Sources/AudiusKit/Models/ImageTypes.swift`
+- `Sources/AudiusKit/Networking/AudiusAPIClient.swift`
+- `Sources/AudiusKit/Networking/CacheManager.swift`
+
+#### Changes Made:
+- **SwiftUI**: Added conditional imports using `#if canImport(SwiftUI)` directive
+- **Network**: Added conditional imports using `#if canImport(Network)` directive  
+- **OSLog**: Added conditional imports using `#if canImport(OSLog)` directive
+
+### 2. Critical Bug Fix
+Fixed incorrect return type in `fetchUserPlaylists` method:
+
+#### Issue:
+- Method was returning `[Track]` instead of `[Playlist]`
+- Method was using `TracksResponse` instead of `PlaylistsResponse`
+- Cache was storing the wrong type
+
+#### Fix:
+- Changed return type from `[Track]` to `[Playlist]`
+- Updated response type from `TracksResponse` to `PlaylistsResponse`
+- Updated cache type annotations to match
+
+### 3. Documentation Update
+Updated `documentation/API-Reference.md` to reflect the correct return type for `fetchUserPlaylists`.
+
+## Review Findings
+
+### ✅ Completeness Assessment
+The changes appear **COMPLETE** with the following verification:
+
+1. **Conditional Import Coverage**: All three files that import potentially unavailable frameworks have been updated:
+   - `ImageTypes.swift`: SwiftUI conditionally imported
+   - `AudiusAPIClient.swift`: Network and OSLog conditionally imported  
+   - `CacheManager.swift`: SwiftUI conditionally imported
+
+2. **Response Model Support**: Required response models exist:
+   - `PlaylistsResponse` struct is properly defined in `Sources/AudiusKit/Models/Responses.swift`
+   - `PlaylistResponse` struct is properly defined in `Sources/AudiusKit/Models/Responses.swift`
+   - `Playlist` struct is properly defined with correct properties
+
+3. **Documentation Consistency**: API documentation has been updated to reflect the bug fix.
+
+### ✅ Accuracy Assessment
+The changes are **ACCURATE**:
+
+1. **Conditional Import Syntax**: All conditional imports use the correct Swift syntax (`#if canImport(FrameworkName)`)
+
+2. **Bug Fix Correctness**: The `fetchUserPlaylists` method now correctly:
+   - Returns `[Playlist]` instead of `[Track]`
+   - Uses `PlaylistsResponse` instead of `TracksResponse`
+   - Maintains consistent cache typing
+
+3. **Method Signature Consistency**: All related methods (`fetchPlaylists`, `fetchPlaylistByPermalink`) correctly use `Playlist` types.
+
+### ✅ Platform Compatibility
+The changes properly address Linux compatibility:
+
+1. **SwiftUI**: Conditionally imported in files that use UI-related types
+2. **Network**: Conditionally imported where network monitoring is used  
+3. **OSLog**: Conditionally imported where logging is used
+4. **Platform-specific Code**: Existing platform-specific code (UIKit/AppKit) remains properly guarded
+
+### ✅ No Regressions Detected
+The changes don't introduce any apparent regressions:
+
+1. All existing functionality is preserved
+2. No breaking changes to public API (except the bug fix, which is a correction)
+3. Cache management remains consistent
+4. Error handling patterns are maintained
+
+## Recommendations
+
+### ✅ Ready for Merge
+The changes are **complete and accurate** and ready for merge. The branch successfully:
+
+1. ✅ Implements proper Linux compatibility through conditional imports
+2. ✅ Fixes a critical bug in the `fetchUserPlaylists` method
+3. ✅ Maintains API consistency and documentation
+4. ✅ Follows established patterns in the codebase
+5. ✅ Includes all necessary supporting code (response models, etc.)
+
+### Additional Notes
+- The conditional import approach is the correct solution for cross-platform Swift packages
+- The bug fix addresses a type mismatch that would cause runtime issues
+- All response models and supporting infrastructure are properly implemented
+- The changes follow Swift Package Manager best practices for Linux compatibility
+
+## Conclusion
+**APPROVED**: The branch changes are complete, accurate, and ready for merge. The Linux compatibility improvements are properly implemented, and the critical bug fix has been correctly addressed with all supporting infrastructure in place.

--- a/Sources/AudiusKit/Models/ImageTypes.swift
+++ b/Sources/AudiusKit/Models/ImageTypes.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if canImport(SwiftUI)
 import SwiftUI
-#endif
 
 #if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit

--- a/Sources/AudiusKit/Networking/AudiusAPIClient.swift
+++ b/Sources/AudiusKit/Networking/AudiusAPIClient.swift
@@ -1,10 +1,6 @@
 import Foundation
-#if canImport(Network)
 import Network
-#endif
-#if canImport(OSLog)
 import OSLog
-#endif
 
 /// A client for interacting with the Audius API
 public actor AudiusAPIClient {

--- a/Sources/AudiusKit/Networking/CacheManager.swift
+++ b/Sources/AudiusKit/Networking/CacheManager.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if canImport(SwiftUI)
 import SwiftUI
-#endif
 
 #if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Revert unnecessary Linux compatibility imports and fix `fetchUserPlaylists` method to return `[Playlist]` instead of `[Track]`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `fetchUserPlaylists` method was incorrectly returning `[Track]` and using `TracksResponse`, leading to type mismatches and incorrect data retrieval. This PR corrects the method to return `[Playlist]` and use `PlaylistsResponse`. Linux compatibility imports were removed as they are out of scope for this Swift library.